### PR TITLE
Fixed rendering bug for wasm version on retina screens

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -168,7 +168,11 @@ impl App {
             fullscreen: options.fullscreen,
         });
         let gl = uni_gl::WebGLRenderingContext::new(app.canvas());
-        gl.viewport(0, 0, options.screen_width, options.screen_height);
+        gl.viewport(
+            0,
+            0, 
+            options.screen_width * app.hidpi_factor() as u32, 
+            options.screen_height * app.hidpi_factor() as u32);
         gl.enable(uni_gl::Flag::Blend as i32);
         gl.clear_color(0.0, 0.0, 0.0, 1.0);
         gl.clear(uni_gl::BufferBit::Color);


### PR DESCRIPTION
New Macs with retina screens render one virtual pixel per four physical pixels. WebGL deals in physical pixels, and this was leading the WASM builds to render as a tiny box in the bottom-left quarter of the viewport. The uni-app library allows access to the correct scaling-factor with the [`hidpi_factor()`](https://docs.rs/uni-app/0.1.0/uni_app/sys/struct.App.html#method.hidpi_factor) function and I just multiply the `screen_width` and `screen_height` variables by it when setting the WebGL viewport.

For most computers this scaling factor is just 1.0f64, and for most Macs it's 2.0f64. Please note that I haven't tested this version on anything except a Mac, but I submitted it now as I can't see how it would possibly break anything. I'll test it on my work PC in the morning.

**Edit:** I've now checked it on a Windows 10 PC with a 1080p monitor, and everything looks fine. 