### PR TITLE
iterators for pressed and released keys

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,4 +16,4 @@ pub use self::color::*;
 pub use self::console::*;
 pub use self::file::FileLoader;
 pub use self::img::*;
-pub use self::input::InputApi;
+pub use self::input::{InputApi, Keys};


### PR DESCRIPTION
I needed/wanted some way to get all the keys that had been pressed or released since the last update, since I wanted to support entering text/numbers. Having to do something like
```rust
if api.input().key_released("Digit1") {
    field_value.push('1');
} else if api.input().key_released("Digit2") {
    field_value.push('2');
}
// etc.
```
would get old fast. With my addition, I could instead do this:
```rust
for key in api
    .input()
    .keys_released()
    .filter(|&k| k.starts_with("Digit"))
{
    let key_char = key.as_bytes()[5] as char;

    field_value.push(key_char);
}
```
While it's not perfect, since you have to do some sub-string casting trickery to extract the value, it's still heaps better.

At first I implemented this by returning a `Vec<&str>`, but I decided to switch to using an iterator instead, to avoid unnecessary allocation. What else are you going to do but iterate over these values anyway?