### PR TITLE
added screenshot functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.2.4 - 2020 Jan 29
+* added option to return `UpdateEvent::Capture` from the `update()` function to capture screenshots in-game
+
 # 1.2.3 - 2020 Jan 08
 * fixed #22 : mouse coordinates broken when console is resized
 * fixed resizable console not taking hidpi factor into account

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -8,3 +8,4 @@
 * Michael Ortmann (TheElec)
 * Daniel Rivas (drivasperez)
 * Alexander Krivács Schrøder (alexschrod)
+* Joshua Wong (imoea)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Uses the uni-gl and uni-app crates from the [unrust](http://github.com/unrust/un
 + [x] subcell resolution
 + [x] PNG image blitting
 + [x] unicode support
++ [x] screenshots
 ```
 
 # demos

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -2,6 +2,11 @@ extern crate doryen_rs;
 
 use doryen_rs::{App, AppOptions, DoryenApi, Engine, TextAlign, UpdateEvent};
 
+/*
+Apart from the basic real-time walking, this example shows how screenshots can be captured in-game.
+Because it uses UpdateEvent, any combination of keys can be specified to activate it.
+*/
+
 const CONSOLE_WIDTH: u32 = 80;
 const CONSOLE_HEIGHT: u32 = 45;
 
@@ -29,6 +34,12 @@ impl Engine for MyRoguelike {
             self.player_pos.1 = (self.player_pos.1 + 1).min(CONSOLE_HEIGHT as i32 - 2);
         }
         self.mouse_pos = input.mouse_pos();
+
+        // capture the screen
+        if input.key("ControlLeft") && input.key_pressed("KeyS") {
+            return Some(UpdateEvent::Capture);
+        }
+
         None
     }
     fn render(&mut self, api: &mut dyn DoryenApi) {


### PR DESCRIPTION
Not necessary but nice to have for gamedev purposes. Screenshots are currently saved as PNGs in the root game directory timestamped by unix time. Although I don't think this will work for WASM?