### PR TITLE
KeyEvents instead of a String as input to check whether a key is pressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 ### API breaks
 * FileLoader no longer prepend "www/" to the file path in native mode.
 
+## 1.3.1 - 2023 Jan 13
+### changes
+* added `KeyEvent`s instead of using `String` for handling keys
+* changed examples so they use `KeyEvent`
+
 ## 1.3.0 - 2022 Oct 10
 ### features
 * added option to return `UpdateEvent::Capture` from the `update()` function to capture in-game screenshots

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -9,3 +9,4 @@
 * Daniel Rivas (drivasperez)
 * Alexander Krivács Schrøder (alexschrod)
 * Joshua Wong (imoea)
+* Koen Beerta (slavjuan)

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,6 +1,6 @@
 extern crate doryen_rs;
 
-use doryen_rs::{App, AppOptions, DoryenApi, Engine, TextAlign, UpdateEvent};
+use doryen_rs::{App, AppOptions, DoryenApi, Engine, TextAlign, UpdateEvent, KeyEvent};
 
 // this part makes it possible to compile to wasm32 target
 #[cfg(target_arch = "wasm32")]
@@ -34,21 +34,22 @@ impl Engine for MyRoguelike {
     }
     fn update(&mut self, api: &mut dyn DoryenApi) -> Option<UpdateEvent> {
         let input = api.input();
-        if input.key("ArrowLeft") {
+        if input.key(KeyEvent::ArrowLeft) {
             self.player_pos.0 = (self.player_pos.0 - 1).max(1);
-        } else if input.key("ArrowRight") {
+        } else if input.key(KeyEvent::ArrowRight) {
             self.player_pos.0 = (self.player_pos.0 + 1).min(CONSOLE_WIDTH as i32 - 2);
         }
-        if input.key("ArrowUp") {
+        if input.key(KeyEvent::ArrowUp) {
             self.player_pos.1 = (self.player_pos.1 - 1).max(1);
-        } else if input.key("ArrowDown") {
+        } else if input.key(KeyEvent::ArrowDown) {
             self.player_pos.1 = (self.player_pos.1 + 1).min(CONSOLE_HEIGHT as i32 - 2);
         }
         self.mouse_pos = input.mouse_pos();
 
         // capture the screen
-        if input.key("ControlLeft") && input.key_pressed("KeyS") {
+        if input.key(KeyEvent::Ctrl) && input.key_pressed(KeyEvent::Key('s')) {
             self.screenshot_idx += 1;
+            println!("Screenshot taken");
             return Some(UpdateEvent::Capture(format!(
                 "screenshot_{:03}.png",
                 self.screenshot_idx

--- a/examples/demo/player.rs
+++ b/examples/demo/player.rs
@@ -1,4 +1,4 @@
-use doryen_rs::{Color, DoryenApi};
+use doryen_rs::{Color, DoryenApi, KeyEvent};
 
 pub struct Player {
     pos: (f32, f32),
@@ -15,14 +15,14 @@ impl Player {
     pub fn move_from_input(&self, api: &mut dyn DoryenApi) -> (i32, i32) {
         let input = api.input();
         let mut mov = (0, 0);
-        if input.key("ArrowLeft") || input.key("KeyA") {
+        if input.key(KeyEvent::ArrowLeft) || input.key(KeyEvent::Key('a')) {
             mov.0 = -1;
-        } else if input.key("ArrowRight") || input.key("KeyD") {
+        } else if input.key(KeyEvent::ArrowRight) || input.key(KeyEvent::Key('d')) {
             mov.0 = 1;
         }
-        if input.key("ArrowUp") || input.key("KeyW") {
+        if input.key(KeyEvent::ArrowUp) || input.key(KeyEvent::Key('w')) {
             mov.1 = -1;
-        } else if input.key("ArrowDown") || input.key("KeyS") {
+        } else if input.key(KeyEvent::ArrowDown) || input.key(KeyEvent::Key('s')) {
             mov.1 = 1;
         }
         mov

--- a/examples/exit.rs
+++ b/examples/exit.rs
@@ -1,6 +1,6 @@
 extern crate doryen_rs;
 
-use doryen_rs::{App, AppOptions, Color, DoryenApi, Engine, TextAlign, UpdateEvent};
+use doryen_rs::{App, AppOptions, Color, DoryenApi, Engine, TextAlign, UpdateEvent, KeyEvent};
 
 const WHITE: Color = (255, 255, 255, 255);
 
@@ -29,12 +29,12 @@ impl Engine for MyRoguelike {
     fn update(&mut self, api: &mut dyn DoryenApi) -> Option<UpdateEvent> {
         let input = api.input();
         if self.close_requested {
-            if input.key("KeyY") {
+            if input.key(KeyEvent::Key('Y')) {
                 return Some(UpdateEvent::Exit);
-            } else if input.key("KeyN") {
+            } else if input.key(KeyEvent::Key('N')) {
                 self.close_requested = false;
             }
-        } else if input.key("Escape") || input.close_requested() {
+        } else if input.key(KeyEvent::Esc) || input.close_requested() {
             self.close_requested = true;
         }
         None

--- a/examples/fonts.rs
+++ b/examples/fonts.rs
@@ -1,6 +1,6 @@
 extern crate doryen_rs;
 
-use doryen_rs::{App, AppOptions, DoryenApi, Engine, TextAlign, UpdateEvent};
+use doryen_rs::{App, AppOptions, DoryenApi, Engine, TextAlign, UpdateEvent, KeyEvent};
 
 // this part makes it possible to compile to wasm32 target
 #[cfg(target_arch = "wasm32")]
@@ -47,10 +47,10 @@ impl Engine for MyRoguelike {
         let mut font_path = None;
         {
             let input = api.input();
-            if input.key_released("PageDown") {
+            if input.key_released(KeyEvent::PageDown) {
                 self.cur_font = (self.cur_font + 1) % FONTS.len();
                 font_path = Some(FONTS[self.cur_font]);
-            } else if input.key_released("PageUp") {
+            } else if input.key_released(KeyEvent::PageDown) {
                 self.cur_font = (self.cur_font + FONTS.len() - 1) % FONTS.len();
                 font_path = Some(FONTS[self.cur_font]);
             }

--- a/examples/text_input.rs
+++ b/examples/text_input.rs
@@ -2,7 +2,7 @@ extern crate doryen_rs;
 
 use unicode_segmentation::UnicodeSegmentation;
 
-use doryen_rs::{App, AppOptions, Color, DoryenApi, Engine, TextAlign, UpdateEvent};
+use doryen_rs::{App, AppOptions, Color, DoryenApi, Engine, TextAlign, UpdateEvent, KeyEvent};
 
 // this part makes it possible to compile to wasm32 target
 #[cfg(target_arch = "wasm32")]
@@ -30,7 +30,7 @@ impl Engine for MyRoguelike {
             self.txt.push_str(&txt);
         }
         // handle backspace
-        if input.key_released("Backspace") && !self.txt.is_empty() {
+        if input.key_released(KeyEvent::Backspace) && !self.txt.is_empty() {
             // convoluted way to remove the last character of the string
             // in a way that also works with utf-8 graphemes
             // where one character != one byte
@@ -39,7 +39,7 @@ impl Engine for MyRoguelike {
             self.txt = graphemes.rev().collect();
         }
         // handle tab
-        if input.key_released("Tab") {
+        if input.key_released(KeyEvent::Tab) {
             self.txt.push_str("   ");
         }
         self.cursor += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,4 +16,4 @@ pub use self::color::*;
 pub use self::console::*;
 pub use self::file::FileLoader;
 pub use self::img::*;
-pub use self::input::{InputApi, Keys};
+pub use self::input::{InputApi, KeyEvent, Keys};


### PR DESCRIPTION
I just started using this crate and thought the input.key() function with a String as parameter was a bit odd since I didn't really know what options I had. I know there was a reference to the unrust [uni-api](https://github.com/unrust/uni-app/blob/41246b070567e3267f128fff41ededf708149d60/src/native_keycode.rs#L160) but I thought using an enum was simpler, this also autocompletes with rust-analyzer so you can see every option you have.

I also changed the example code to have these KeyEvents