### PR TITLE
add clone + debug to options

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -124,6 +124,7 @@ pub trait Engine {
     fn resize(&mut self, _api: &mut dyn DoryenApi) {}
 }
 
+#[derive(Debug, Clone)]
 pub struct AppOptions {
     /// the console width in characters. Default is 80
     pub console_width: u32,

--- a/src/console.rs
+++ b/src/console.rs
@@ -26,6 +26,7 @@ pub enum TextAlign {
 }
 
 /// This contains the data for a console (including the one displayed on the screen) and methods to draw on it.
+#[derive(Debug)]
 pub struct Console {
     width: u32,
     height: u32,


### PR DESCRIPTION
Was hoping to add clone to AppOptions. I am building an interface to inject doryen into bevy and would like to easily clone the options from the plugin. I added debug just so I could easily debug as i test. Let me know if thats okay!